### PR TITLE
chore: Bump `golangci-lint` to `v2`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,4 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[docker] "
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,4 +27,3 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[docker] "
-

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -31,7 +31,7 @@ jobs:
       repository-projects: read
       security-events: write
       statuses: read
-    uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@0.1.6
+    uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@0.1.7
     with:
       run_version_check: true
       run_version_tag: true

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -15,7 +15,7 @@ permissions: {}
 jobs:
   post-merge:
     permissions:
-      # it combines `read-all` with `contents: write` - all of them needed by `post-merge.yml` workflow
+      # it combines `read-all` with `contents: write` and `security-events: write` - all of them needed by `post-merge.yml` workflow
       contents: write
       actions: read
       attestations: read
@@ -29,14 +29,13 @@ jobs:
       pages: read
       pull-requests: read
       repository-projects: read
-      security-events: read
+      security-events: write
       statuses: read
-    uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@0.1.5
+    uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@0.1.6
     with:
       run_version_check: true
       run_version_tag: true
-      bootstrap_tools: "go,gotools,nodejs,python,golang-lint,helm,shellcheck,hadolint,yq,jq,protolint"
-      run_security_scans: true
+      bootstrap_tools: "go,gotools,nodejs,python,golangci-lint2,helm,shellcheck,hadolint,yq,jq,protolint"
       run_dep_version_check: false
       cache_go: true
       run_build: true

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -16,7 +16,7 @@ jobs:
   pre-merge:
     permissions:
       contents: write
-    uses: open-edge-platform/orch-ci/.github/workflows/pre-merge.yml@0.1.6
+    uses: open-edge-platform/orch-ci/.github/workflows/pre-merge.yml@0.1.7
     with:
       run_reuse_check: true
       run_version_check: true

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -16,11 +16,11 @@ jobs:
   pre-merge:
     permissions:
       contents: write
-    uses: open-edge-platform/orch-ci/.github/workflows/pre-merge.yml@0.1.5
+    uses: open-edge-platform/orch-ci/.github/workflows/pre-merge.yml@0.1.6
     with:
       run_reuse_check: true
       run_version_check: true
-      bootstrap_tools: "go,gotools,nodejs,python,golang-lint,helm,shellcheck,hadolint,yq,jq,protolint"
+      bootstrap_tools: "go,gotools,nodejs,python,golangci-lint2,helm,shellcheck,hadolint,yq,jq,protolint"
       run_dep_version_check: false
       cache_go: true
       run_build: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,16 @@
 # SPDX-FileCopyrightText: (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+version: "2"
+
 linters:
-  disable-all: true
+  # Default set of linters.
+  # The value can be: `standard`, `all`, `none`, or `fast`.
+  # Default: standard
+  default: none
+
+  # Enable specific linter.
+  # https://golangci-lint.run/usage/linters/#enabled-by-default
   enable:
     - asasalint
     - asciicheck
@@ -13,20 +21,18 @@ linters:
     - dogsled
     - dupword
     - durationcheck
-    - errchkjson
     - errcheck
+    - errchkjson
     - errname
     - errorlint
     - exhaustive
     - exptostd
-    - gci
     - ginkgolinter
     - gocheckcompilerdirectives
     - gocritic
     - godot
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - interfacebloat
@@ -57,322 +63,359 @@ linters:
     - wastedassign
     - whitespace
 
-linters-settings:
-  errcheck:
-    # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`.
-    # Such cases aren't reported by default.
-    # Default: false
-    check-blank: true
+  settings:
+    errcheck:
+      # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`.
+      # Such cases aren't reported by default.
+      # Default: false
+      check-blank: true
 
-    # List of functions to exclude from checking, where each entry is a single function to exclude.
-    # See https://github.com/kisielk/errcheck#excluding-functions for details.
-    exclude-functions:
-      - "(*hash/maphash.Hash).Write"
-      - "(*hash/maphash.Hash).WriteByte"
-      - "(*hash/maphash.Hash).WriteString"
-  exhaustive:
-    # Presence of "default" case in switch statements satisfies exhaustiveness,
-    # even if all enum members are not listed.
-    # Default: false
-    default-signifies-exhaustive: true
-  gci:
-    # Section configuration to compare against.
-    # Section names are case-insensitive and may contain parameters in ().
-    # The default order of sections is `standard > default > custom > blank > dot > alias > localmodule`,
-    # If `custom-order` is `true`, it follows the order of `sections` option.
-    # Default: ["standard", "default"]
-    sections:
-      - standard                       # Standard section: captures all standard packages.
-      - default                        # Default section: contains all imports that could not be matched to another section type.
-      - localmodule                    # Local module section: contains all local packages. This section is not present unless explicitly enabled.
-  gocritic:
-    # Disable all checks.
-    # Default: false
-    disable-all: true
-    # Which checks should be enabled in addition to default checks; can't be combined with 'disabled-checks'.
-    # By default, list of stable checks is used (https://go-critic.com/overview#checks-overview).
-    # To see which checks are enabled run `GL_DEBUG=gocritic golangci-lint run --enable=gocritic`.
-    enabled-checks:
-      # diagnostic
-      - argOrder
-      - badCall
-      - badCond
-      - badLock
-      - badRegexp
-      - badSorting
-      - badSyncOnceFunc
-      - builtinShadowDecl
-      - caseOrder
-      - codegenComment
-      - commentedOutCode
-      - deferInLoop
-      - deprecatedComment
-      - dupArg
-      - dupBranchBody
-      - dupCase
-      - dupSubExpr
-      - dynamicFmtString
-      - emptyDecl
-      - evalOrder
-      - exitAfterDefer
-      - externalErrorReassign
-      - filepathJoin
-      - flagName
-      - mapKey
-      - nilValReturn
-      - offBy1
-      - regexpPattern
-      - sloppyLen
-      - sloppyReassign
-      - sloppyTypeAssert
-      - sortSlice
-      - sprintfQuotedString
-      - sqlQuery
-      - syncMapLoadAndDelete
-      - truncateCmp
-      - uncheckedInlineErr
-      - unnecessaryDefer
-      - weakCond
-      # performance
-      - appendCombine
-      - equalFold
-      - hugeParam
-      - indexAlloc
-      - preferDecodeRune
-      - preferFprint
-      - preferStringWriter
-      - preferWriteByte
-      - rangeExprCopy
-      - rangeValCopy
-      - sliceClear
-      - stringXbytes
+      # List of functions to exclude from checking, where each entry is a single function to exclude.
+      # See https://github.com/kisielk/errcheck#excluding-functions for details.
+      exclude-functions:
+        - '(*hash/maphash.Hash).Write'
+        - '(*hash/maphash.Hash).WriteByte'
+        - '(*hash/maphash.Hash).WriteString'
 
-    # Settings passed to gocritic.
-    # The settings key is the name of a supported gocritic checker.
-    # The list of supported checkers can be find in https://go-critic.com/overview.
-    settings:
-      hugeParam:
-        # Size in bytes that makes the warning trigger.
-        # Default: 80
-        sizeThreshold: 512
-      rangeValCopy:
-        # Size in bytes that makes the warning trigger.
-        # Default: 128
-        sizeThreshold: 512
+    exhaustive:
+      # Presence of "default" case in switch statements satisfies exhaustiveness,
+      # even if all enum members are not listed.
+      # Default: false
+      default-signifies-exhaustive: true
 
-  gosec:
-    # To select a subset of rules to run.
-    # Available rules: https://github.com/securego/gosec#available-rules
-    # Default: [] - means include all rules
-    includes:
-      - G101 # Look for hard coded credentials
-      - G102 # Bind to all interfaces
-      - G103 # Audit the use of unsafe block
-      - G106 # Audit the use of ssh.InsecureIgnoreHostKey
-      - G107 # Url provided to HTTP request as taint input
-      - G108 # Profiling endpoint automatically exposed on /debug/pprof
-      - G109 # Potential Integer overflow made by strconv.Atoi result conversion to int16/32
-      - G110 # Potential DoS vulnerability via decompression bomb
-      - G111 # Potential directory traversal
-      - G112 # Potential slowloris attack
-      - G114 # Use of net/http serve function that has no support for setting timeouts
-      - G201 # SQL query construction using format string
-      - G202 # SQL query construction using string concatenation
-      - G203 # Use of unescaped data in HTML templates
-      - G301 # Poor file permissions used when creating a directory
-      - G302 # Poor file permissions used with chmod
-      - G303 # Creating tempfile using a predictable path
-      - G305 # File traversal when extracting zip/tar archive
-      - G306 # Poor file permissions used when writing to a new file
-      - G401 # Detect the usage of MD5 or SHA1
-      - G403 # Ensure minimum RSA key length of 2048 bits
-      - G404 # Insecure random number source (rand)
-      - G405 # Detect the usage of DES or RC4
-      - G406 # Detect the usage of MD4 or RIPEMD160
-      - G501 # Import blocklist: crypto/md5
-      - G502 # Import blocklist: crypto/des
-      - G503 # Import blocklist: crypto/rc4
-      - G505 # Import blocklist: crypto/sha1
-      - G506 # Import blocklist: golang.org/x/crypto/md4
-      - G507 # Import blocklist: golang.org/x/crypto/ripemd160
-      - G601 # Implicit memory aliasing of items from a range statement
-      - G602 # Slice access out of bounds
+    gocritic:
+      # Disable all checks.
+      # Default: false
+      disable-all: true
+      # Which checks should be enabled in addition to default checks; can't be combined with 'disabled-checks'.
+      # By default, list of stable checks is used (https://go-critic.com/overview#checks-overview).
+      # To see which checks are enabled run `GL_DEBUG=gocritic golangci-lint run --enable=gocritic`.
+      enabled-checks:
+        # diagnostic
+        - argOrder
+        - badCall
+        - badCond
+        - badLock
+        - badRegexp
+        - badSorting
+        - badSyncOnceFunc
+        - builtinShadowDecl
+        - caseOrder
+        - codegenComment
+        - commentedOutCode
+        - deferInLoop
+        - deprecatedComment
+        - dupArg
+        - dupBranchBody
+        - dupCase
+        - dupSubExpr
+        - dynamicFmtString
+        - emptyDecl
+        - evalOrder
+        - exitAfterDefer
+        - externalErrorReassign
+        - filepathJoin
+        - flagName
+        - mapKey
+        - nilValReturn
+        - offBy1
+        - regexpPattern
+        - sloppyLen
+        - sloppyReassign
+        - sloppyTypeAssert
+        - sortSlice
+        - sprintfQuotedString
+        - sqlQuery
+        - syncMapLoadAndDelete
+        - truncateCmp
+        - uncheckedInlineErr
+        - unnecessaryDefer
+        - weakCond
+        # performance
+        - appendCombine
+        - equalFold
+        - hugeParam
+        - indexAlloc
+        - preferDecodeRune
+        - preferFprint
+        - preferStringWriter
+        - preferWriteByte
+        - rangeExprCopy
+        - rangeValCopy
+        - sliceClear
+        - stringXbytes
+
+      # Settings passed to gocritic.
+      # The settings key is the name of a supported gocritic checker.
+      # The list of supported checkers can be found at https://go-critic.com/overview.
+      settings:
+        hugeParam:
+          # Size in bytes that makes the warning trigger.
+          # Default: 80
+          sizeThreshold: 512
+        rangeValCopy:
+          # Size in bytes that makes the warning trigger.
+          # Default: 128
+          sizeThreshold: 512
+
+    gosec:
+      # To select a subset of rules to run.
+      # Available rules: https://github.com/securego/gosec#available-rules
+      # Default: [] - means include all rules
+      includes:
+        - G101 # Look for hard coded credentials
+        - G102 # Bind to all interfaces
+        - G103 # Audit the use of unsafe block
+        - G106 # Audit the use of ssh.InsecureIgnoreHostKey
+        - G107 # Url provided to HTTP request as taint input
+        - G108 # Profiling endpoint automatically exposed on /debug/pprof
+        - G109 # Potential Integer overflow made by strconv.Atoi result conversion to int16/32
+        - G110 # Potential DoS vulnerability via decompression bomb
+        - G111 # Potential directory traversal
+        - G112 # Potential slowloris attack
+        - G114 # Use of net/http serve function that has no support for setting timeouts
+        - G201 # SQL query construction using format string
+        - G202 # SQL query construction using string concatenation
+        - G203 # Use of unescaped data in HTML templates
+        - G301 # Poor file permissions used when creating a directory
+        - G302 # Poor file permissions used with chmod
+        - G303 # Creating tempfile using a predictable path
+        - G305 # File traversal when extracting zip/tar archive
+        - G306 # Poor file permissions used when writing to a new file
+        - G401 # Detect the usage of MD5 or SHA1
+        - G403 # Ensure minimum RSA key length of 2048 bits
+        - G404 # Insecure random number source (rand)
+        - G405 # Detect the usage of DES or RC4
+        - G406 # Detect the usage of MD4 or RIPEMD160
+        - G501 # Import blocklist: crypto/md5
+        - G502 # Import blocklist: crypto/des
+        - G503 # Import blocklist: crypto/rc4
+        - G505 # Import blocklist: crypto/sha1
+        - G506 # Import blocklist: golang.org/x/crypto/md4
+        - G507 # Import blocklist: golang.org/x/crypto/ripemd160
+        - G601 # Implicit memory aliasing of items from a range statement
+        - G602 # Slice access out of bounds
       # G104, G105, G113, G204, G304, G307, G402, G504 were not enabled intentionally
       # TODO: review G115 when reporting false positives is fixed (https://github.com/securego/gosec/issues/1212)
-    # To specify the configuration of rules.
-    config:
-      # Maximum allowed permissions mode for os.OpenFile and os.Chmod
-      # Default: "0600"
-      G302: "0640"
-      # Maximum allowed permissions mode for os.WriteFile and ioutil.WriteFile
-      # Default: "0600"
-      G306: "0640"
-  lll:
-    # Max line length, lines longer will be reported.
-    # '\t' is counted as 1 character by default, and can be changed with the tab-width option.
-    # Default: 120.
-    line-length: 160
-    # Tab width in spaces.
-    # Default: 1
-    tab-width: 4
-  nakedret:
-    # Make an issue if func has more lines of code than this setting, and it has naked returns.
-    # Default: 30
-    max-func-lines: 1
-  nolintlint:
-    # Enable to require an explanation of nonzero length after each nolint directive.
-    # Default: false
-    require-explanation: true
-    # Enable to require nolint directives to mention the specific linter being suppressed.
-    # Default: false
-    require-specific: true
-  prealloc:
-    # Report pre-allocation suggestions only on simple loops that have no returns/breaks/continues/gotos in them.
-    # Default: true
-    simple: false
-  revive:
-    rules:
-      - name: argument-limit
-        arguments: [ 6 ]
-      - name: atomic
-      - name: bare-return
-      - name: blank-imports
-      - name: bool-literal-in-expr
-      - name: call-to-gc
-      - name: comment-spacings
-      - name: confusing-naming
-      - name: confusing-results
-      - name: constant-logical-expr
-      - name: context-as-argument
-      - name: context-keys-type
-      - name: datarace
-      - name: deep-exit
-      - name: defer
-      - name: dot-imports
-      - name: duplicated-imports
-      - name: early-return
-      - name: empty-block
-      - name: empty-lines
-      - name: error-naming
-      - name: error-return
-      - name: error-strings
-      - name: errorf
-      - name: flag-parameter
-      - name: function-result-limit
-        arguments: [ 4 ]
-      - name: get-return
-      - name: identical-branches
-      - name: if-return
-      - name: import-alias-naming
-        arguments:
-          - "^[a-z][a-z0-9_]*[a-z0-9]+$"
-      - name: import-shadowing
-      - name: increment-decrement
-      - name: indent-error-flow
-      - name: max-public-structs
-        exclude: ["TEST"]
-        arguments: [5]
-      - name: modifies-parameter
-      - name: modifies-value-receiver
-      - name: optimize-operands-order
-      - name: package-comments
-      - name: range
-      - name: range-val-address
-      - name: range-val-in-closure
-      - name: receiver-naming
-      - name: redefines-builtin-id
-      - name: redundant-import-alias
-      - name: string-of-int
-      - name: struct-tag
-      - name: superfluous-else
-      - name: time-equal
-      - name: time-naming
-      - name: unconditional-recursion
-      - name: unexported-naming
-      - name: unnecessary-stmt
-      - name: unreachable-code
-      - name: unused-parameter
-      - name: unused-receiver
-      - name: var-declaration
-      - name: var-naming
-      - name: waitgroup-by-value
-  testifylint:
-    # Disable all checkers (https://github.com/Antonboom/testifylint#checkers).
-    # Default: false
-    disable-all: true
-    # Enable checkers by name
-    enable:
-      - blank-import
-      - bool-compare
-      - compares
-      - contains
-      - empty
-      - encoded-compare
-      - error-is-as
-      - error-nil
-      - expected-actual
-      - float-compare
-      - formatter
-      - go-require
-      - len
-      - negative-positive
-      - nil-compare
-      - regexp
-      - require-error
-      - suite-broken-parallel
-      - suite-dont-use-pkg
-      - suite-extra-assert-call
-      - suite-subtest-run
-      - suite-thelper
-      - useless-assert
-    go-require:
-      # To ignore HTTP handlers (like http.HandlerFunc).
-      # Default: false
-      ignore-http-handlers: true
 
-  usetesting:
-    # Enable/disable `os.TempDir()` detections.
-    # Default: false
-    os-temp-dir: true
+      # To specify the configuration of rules.
+      config:
+        # Maximum allowed permissions mode for os.OpenFile and os.Chmod
+        # Default: "0600"
+        G302: "0640"
+        # Maximum allowed permissions mode for os.WriteFile and ioutil.WriteFile
+        # Default: "0600"
+        G306: "0640"
+
+    lll:
+      # Max line length, lines longer will be reported.
+      # '\t' is counted as 1 character by default, and can be changed with the tab-width option.
+      # Default: 120.
+      line-length: 160
+      # Tab width in spaces.
+      # Default: 1
+      tab-width: 4
+
+    nakedret:
+      # Make an issue if func has more lines of code than this setting, and it has naked returns.
+      # Default: 30
+      max-func-lines: 1
+
+    nolintlint:
+      # Enable to require an explanation of nonzero length after each nolint directive.
+      # Default: false
+      require-explanation: true
+      # Enable to require nolint directives to mention the specific linter being suppressed.
+      # Default: false
+      require-specific: true
+
+    prealloc:
+      # Report pre-allocation suggestions only on simple loops that have no returns/breaks/continues/gotos in them.
+      # Default: true
+      simple: false
+
+    revive:
+      # Sets the default severity.
+      # See https://github.com/mgechev/revive#configuration
+      # Default: warning
+      severity: error
+
+      # Run `GL_DEBUG=revive golangci-lint run --enable-only=revive` to see default, all available rules, and enabled rules.
+      rules:
+        - name: argument-limit
+          arguments: [ 6 ]
+        - name: atomic
+        - name: bare-return
+        - name: blank-imports
+        - name: bool-literal-in-expr
+        - name: call-to-gc
+        - name: comment-spacings
+        - name: confusing-naming
+        - name: confusing-results
+        - name: constant-logical-expr
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: datarace
+        - name: deep-exit
+        - name: defer
+        - name: dot-imports
+        - name: duplicated-imports
+        - name: early-return
+        - name: empty-block
+        - name: empty-lines
+        - name: error-naming
+        - name: error-return
+        - name: error-strings
+        - name: errorf
+        - name: flag-parameter
+        - name: function-result-limit
+          arguments: [ 4 ]
+        - name: get-return
+        - name: identical-branches
+        - name: if-return
+        - name: import-alias-naming
+          arguments:
+            - "^[a-z][a-z0-9_]*[a-z0-9]+$"
+        - name: import-shadowing
+        - name: increment-decrement
+        - name: indent-error-flow
+        - name: max-public-structs
+          arguments: [ 5 ]
+          exclude: [ "TEST" ]
+        - name: modifies-parameter
+        - name: modifies-value-receiver
+        - name: optimize-operands-order
+        - name: package-comments
+        - name: range
+        - name: range-val-address
+        - name: range-val-in-closure
+        - name: receiver-naming
+        - name: redefines-builtin-id
+        - name: redundant-import-alias
+        - name: string-of-int
+        - name: struct-tag
+        - name: superfluous-else
+        - name: time-equal
+        - name: time-naming
+        - name: unconditional-recursion
+        - name: unexported-naming
+        - name: unnecessary-stmt
+        - name: unreachable-code
+        - name: unused-parameter
+        - name: unused-receiver
+        - name: var-declaration
+        - name: var-naming
+        - name: waitgroup-by-value
+
+    testifylint:
+      # Disable all checkers (https://github.com/Antonboom/testifylint#checkers).
+      # Default: false
+      disable-all: true
+      # Enable checkers by name
+      enable:
+        - blank-import
+        - bool-compare
+        - compares
+        - contains
+        - empty
+        - encoded-compare
+        - error-is-as
+        - error-nil
+        - expected-actual
+        - float-compare
+        - formatter
+        - go-require
+        - len
+        - negative-positive
+        - nil-compare
+        - regexp
+        - require-error
+        - suite-broken-parallel
+        - suite-dont-use-pkg
+        - suite-extra-assert-call
+        - suite-subtest-run
+        - suite-thelper
+        - useless-assert
+      go-require:
+        # To ignore HTTP handlers (like http.HandlerFunc).
+        # Default: false
+        ignore-http-handlers: true
+
+    usetesting:
+      # Enable/disable `os.TempDir()` detections.
+      # Default: false
+      os-temp-dir: true
+
+  # Defines a set of rules to ignore issues.
+  # It does not skip the analysis, and so does not ignore "typecheck" errors.
+  exclusions:
+    # Mode of the generated files analysis.
+    #
+    # - `strict`: sources are excluded by strictly following the Go generated file convention.
+    #    Source files that have lines matching only the following regular expression will be excluded: `^// Code generated .* DO NOT EDIT\.$`
+    #    This line must appear before the first non-comment, non-blank text in the file.
+    #    https://go.dev/s/generatedcode
+    # - `lax`: sources are excluded if they contain lines like `autogenerated file`, `code generated`, `do not edit`, etc.
+    # - `disable`: disable the generated files exclusion.
+    #
+    # Default: strict
+    generated: lax
+
+    # Excluding configuration per-path, per-linter, per-text and per-source.
+    rules:
+      # gosec:G101
+      - path: _test\.go
+        text: "Potential hardcoded credentials"
+
+      # revive:dot-imports
+      - path: (.+)_test\.go
+        text: should not use dot imports
+
+      # revive:max-public-structs
+      - path: internal/database/models/
+        text: "max-public-structs: you have exceeded the maximum number"
+
+      # EXC0001 errcheck: Almost all programs ignore errors on these functions, and in most cases it's ok
+      - path: (.+)\.go$
+        text: Error return value of .((os\.)?std(out|err)\..*|.*Close.*|.*close.*|.*Flush|.*Disconnect|.*disconnect|.*Clear|os\.Remove(All)?|.*print(f|ln)?|os\.Setenv|os\.Unsetenv). is not checked
+
+      # EXC0015 revive: Annoying issue about not having a comment. The rare codebase has such comments
+      - path: (.+)\.go$
+        text: should have a package comment
+
+formatters:
+  # Enable specific formatter.
+  # Default: [] (uses standard Go formatting)
+  enable:
+    - gci
+
+  # Formatters settings.
+  settings:
+    gci:
+      # Section configuration to compare against.
+      # Section names are case-insensitive and may contain parameters in ().
+      # The default order of sections is `standard > default > custom > blank > dot > alias > localmodule`.
+      # If `custom-order` is `true`, it follows the order of `sections` option.
+      # Default: ["standard", "default"]
+      sections:
+        - standard                       # Standard section: captures all standard packages.
+        - default                        # Default section: contains all imports that could not be matched to another section type.
+        - localmodule                    # Local module section: contains all local packages. This section is not present unless explicitly enabled.
+
+  exclusions:
+    # Mode of the generated files analysis.
+    #
+    # - `strict`: sources are excluded by strictly following the Go generated file convention.
+    #    Source files that have lines matching only the following regular expression will be excluded: `^// Code generated .* DO NOT EDIT\.$`
+    #    This line must appear before the first non-comment, non-blank text in the file.
+    #    https://go.dev/s/generatedcode
+    # - `lax`: sources are excluded if they contain lines like `autogenerated file`, `code generated`, `do not edit`, etc.
+    # - `disable`: disable the generated files exclusion.
+    #
+    # Default: lax
+    generated: lax
 
 issues:
-  # List of regexps of issue texts to exclude.
-  #
-  # But independently of this option we use default exclude patterns,
-  # it can be disabled by `exclude-use-default: false`.
-  # To list all excluded by default patterns execute `golangci-lint run --help`
-  #
-  # Default: https://golangci-lint.run/usage/false-positives/#default-exclusions
-  exclude:
-    # revive:var-naming
-    - don't use an underscore in package name
-    # EXC0001 errcheck: Almost all programs ignore errors on these functions, and in most cases it's ok
-    - Error return value of .((os\.)?std(out|err)\..*|.*Close.*|.*Flush|.*Disconnect|.*Clear|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
-    # EXC0013 revive: Annoying issue about not having a comment. The rare codebase has such comments
-    - package comment should be of the form "(.+)...
-    # EXC0015 revive: Annoying issue about not having a comment. The rare codebase has such comments
-    - should have a package comment
-
-  # Excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules:
-    - path: _test\.go
-      text: "Potential hardcoded credentials" #gosec:G101
-
-    - path: _test\.go
-      text: "Use of weak random number generator" #gosec:G404
-
-    - path: '(.+)_test\.go'
-      text: "should not use dot imports"
-
-    - path: internal/database/models/
-      text: "max-public-structs: you have exceeded the maximum number" #revive:max-public-structs
-
-  # Independently of option `exclude` we use default exclude patterns,
-  # it can be disabled by this option.
-  # To list all excluded by default patterns execute `golangci-lint run --help`.
-  # Default: true
-  exclude-use-default: false
-
   # Maximum issues count per one linter.
   # Set to 0 to disable.
   # Default: 50
@@ -387,49 +430,48 @@ issues:
   # Default: true
   uniq-by-line: false
 
-# output configuration options
+# Output configuration options.
 output:
   # The formats used to render issues.
-  # Formats:
-  # - `colored-line-number`
-  # - `line-number`
-  # - `json`
-  # - `colored-tab`
-  # - `tab`
-  # - `html`
-  # - `checkstyle`
-  # - `code-climate`
-  # - `junit-xml`
-  # - `junit-xml-extended`
-  # - `github-actions`
-  # - `teamcity`
-  # - `sarif`
-  # Output path can be either `stdout`, `stderr` or path to the file to write to.
-  #
-  # For the CLI flag (`--out-format`), multiple formats can be specified by separating them by comma.
-  # The output can be specified for each of them by separating format name and path by colon symbol.
-  # Example: "--out-format=checkstyle:report.xml,json:stdout,colored-line-number"
-  # The CLI flag (`--out-format`) override the configuration file.
-  #
-  # Default:
-  #   formats:
-  #     - format: colored-line-number
-  #       path: stdout
   formats:
-    - format: tab
+    # Prints issues in columns representation separated by tabulations.
+    tab:
+      # Output path can be either `stdout`, `stderr` or path to the file to write to.
+      # Default: stdout
       path: stdout
 
-  # Sort results by the order defined in `sort-order`.
-  # Default: false
-  sort-results: true
+  # Order to use when sorting results.
+  # Possible values: `file`, `linter`, and `severity`.
+  #
+  # If the severity values are inside the following list, they are ordered in this order:
+  #   1. error
+  #   2. warning
+  #   3. high
+  #   4. medium
+  #   5. low
+  # Either they are sorted alphabetically.
+  #
+  # Default: ["linter", "file"]
+  sort-order:
+    - file # filepath, line, and column.
+    - linter
 
   # Show statistics per linter.
-  # Default: false
+  # Default: true
   show-stats: true
 
-# Options for analysis running.
-run:
-  # Timeout for analysis, e.g. 30s, 5m.
-  # If the value is lower or equal to 0, the timeout is disabled.
-  # Default: 1m
-  timeout: 10m
+severity:
+  # Set the default severity for issues.
+  #
+  # If severity rules are defined and the issues do not match or no severity is provided to the rule
+  # this will be the default severity applied.
+  # Severities should match the supported severity names of the selected out format.
+  # - Code climate: https://docs.codeclimate.com/docs/issues#issue-severity
+  # - Checkstyle: https://checkstyle.sourceforge.io/property_types.html#SeverityLevel
+  # - GitHub: https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-error-message
+  # - TeamCity: https://www.jetbrains.com/help/teamcity/service-messages.html#Inspection+Instance
+  #
+  # `@linter` can be used as severity value to keep the severity from linters (e.g. revive, gosec, ...)
+  #
+  # Default: ""
+  default: error

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
 ginkgo 2.22.2
-golang 1.24.0
-golangci-lint 1.64.5
+golang 1.24.2
+golangci-lint 2.1.2
 hadolint 2.12.0
 helm 3.17.0
 jq 1.7.1

--- a/internal/alertmanager/alertmanager_test.go
+++ b/internal/alertmanager/alertmanager_test.go
@@ -25,7 +25,7 @@ func TestGetConfigManifest(t *testing.T) {
 	t.Run("Failed to get alertmanager config secret due to error", func(t *testing.T) {
 		fakeClient := testclient.NewSimpleClientset()
 
-		fakeClient.Fake.PrependReactor("get", "secrets", func(_ ktesting.Action) (handled bool, ret runtime.Object, err error) {
+		fakeClient.PrependReactor("get", "secrets", func(_ ktesting.Action) (handled bool, ret runtime.Object, err error) {
 			return true, nil, errors.New("mock error")
 		})
 
@@ -137,7 +137,7 @@ func TestSetConfigManifest(t *testing.T) {
 	t.Run("Failed to get alertmanager config secret", func(t *testing.T) {
 		fakeClient := testclient.NewSimpleClientset()
 
-		fakeClient.Fake.PrependReactor("get", "secrets", func(_ ktesting.Action) (handled bool, ret runtime.Object, err error) {
+		fakeClient.PrependReactor("get", "secrets", func(_ ktesting.Action) (handled bool, ret runtime.Object, err error) {
 			return true, nil, errors.New("mock error")
 		})
 
@@ -218,7 +218,7 @@ func TestSetConfigManifest(t *testing.T) {
 			},
 		})
 
-		fakeClient.Fake.PrependReactor("update", "secrets", func(_ ktesting.Action) (handled bool, ret runtime.Object, err error) {
+		fakeClient.PrependReactor("update", "secrets", func(_ ktesting.Action) (handled bool, ret runtime.Object, err error) {
 			return true, nil, errors.New("mock error")
 		})
 
@@ -265,7 +265,7 @@ func TestReceiverConfig_UpdateReceiverConfig(t *testing.T) {
 	t.Run("FailToGetManifest", func(t *testing.T) {
 		fakeClient := testclient.NewSimpleClientset()
 
-		fakeClient.Fake.PrependReactor("get", "secrets", func(_ ktesting.Action) (handled bool, ret runtime.Object, err error) {
+		fakeClient.PrependReactor("get", "secrets", func(_ ktesting.Action) (handled bool, ret runtime.Object, err error) {
 			return true, nil, errors.New("mock error")
 		})
 
@@ -343,7 +343,7 @@ route:
 		})
 
 		// mock setting the alertmanager config manifest.
-		fakeClient.Fake.PrependReactor("update", "secrets", func(_ ktesting.Action) (handled bool, ret runtime.Object, err error) {
+		fakeClient.PrependReactor("update", "secrets", func(_ ktesting.Action) (handled bool, ret runtime.Object, err error) {
 			return true, nil, errors.New("mock error")
 		})
 

--- a/internal/app/handlers_test.go
+++ b/internal/app/handlers_test.go
@@ -291,7 +291,7 @@ func assertResponse(t *testing.T, expected string, responseBody *bytes.Buffer) {
 
 	expectedAlerts := unmarshalledExpected.Alerts
 	responseAlerts := unmarshalledResponse.Alerts
-	require.Equal(t, len(*expectedAlerts), len(*responseAlerts), "Number of alerts in expected response and actual response does not match")
+	require.Len(t, *responseAlerts, len(*expectedAlerts), "Number of alerts in expected response and actual response does not match")
 
 	require.Equal(t, unmarshalledExpected, unmarshalledResponse, "Response body different than expected")
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: (C) 2025 Intel Corporation
SPDX-License-Identifier: Apache-2.0
-->

### Description

More info about major version update: https://golangci-lint.run/product/changelog/#201

In this PR:  
- I migrated the `.golangci-lint` config from `v1` to `v2` using: `golangci-lint migrate`: https://golangci-lint.run/product/migration-guide/.  
- I supplemented the resulting config with removed comments and made it as similar as possible to https://github.com/golangci/golangci-lint/blob/main/.golangci.reference.yml to facilitate future diffs.  
- The linters `staticcheck`, `stylecheck`, and `gosimple` have been merged into a single linter (`staticcheck`). Few new issues were detected by `staticcheck`.
- Other minor config changes were made to align with the new schema.  
- I fixed new findings:
  ```
  internal/alertmanager/alertmanager_test.go:28:14   staticcheck  QF1008: could remove embedded field "Fake" from selector
  internal/alertmanager/alertmanager_test.go:140:14  staticcheck  QF1008: could remove embedded field "Fake" from selector
  internal/alertmanager/alertmanager_test.go:221:14  staticcheck  QF1008: could remove embedded field "Fake" from selector
  internal/alertmanager/alertmanager_test.go:268:14  staticcheck  QF1008: could remove embedded field "Fake" from selector
  internal/alertmanager/alertmanager_test.go:346:14  staticcheck  QF1008: could remove embedded field "Fake" from selector
  internal/app/handlers_test.go:294:2                testifylint  len: use require.Len
  ```


### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
