### PR TITLE
Fixing cooldown issue in code scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[gomod] "
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -18,6 +20,8 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[gha] "
+    cooldown:
+      default-days: 7
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
@@ -25,3 +29,5 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[docker] "
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This pull request adds a cooldown period to Dependabot updates for Go modules, GitHub Actions, and Docker dependencies. This helps reduce noise by ensuring that Dependabot will wait at least 7 days before creating another pull request for the same dependency.

Dependabot configuration improvements:

* Added a `cooldown` setting with `default-days: 7` to the Go modules, GitHub Actions, and Docker sections in `.github/dependabot.yml` to limit the frequency of pull requests for the same dependency.