### PR TITLE
Enable post-merge security scans for tag creation

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -9,6 +9,8 @@ on:
     branches:
       - main
       - release-*
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow trigger configuration in `.github/workflows/post-merge.yml` to ensure workflows also run on new tags, in addition to the existing triggers.

Workflow trigger improvements:

* Modified the `on:` section to trigger the workflow on any new tag (`tags: ['*']`), so the workflow will run not only on pushes to `main` and `release-*` branches, but also when a new tag is pushed.