### PR TITLE
Remove post merge on tag

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -9,8 +9,6 @@ on:
     branches:
       - main
       - release-*
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request makes a small change to the GitHub Actions workflow configuration. The workflow will no longer be triggered by tags, and will only run on pushes to the `main` and `release-*` branches or via manual dispatch.